### PR TITLE
【認証】ログイン時のToken保存

### DIFF
--- a/actions/token.ts
+++ b/actions/token.ts
@@ -2,6 +2,15 @@
 
 import { cookies } from "next/headers";
 
+export const setToken = async (token: string) => {
+  const store = await cookies();
+  store.set("token", token, {
+    httpOnly: true,
+    path: "/",
+    maxAge: 60 * 60 * 24 * 7, // 7日
+  });
+};
+
 export const getToken = async (): Promise<string | undefined> => {
   const store = await cookies();
   return store.get("token")?.value;

--- a/features/auth/components/organisms/SigninForm.tsx
+++ b/features/auth/components/organisms/SigninForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { setToken } from "@/actions/token";
 import { IconLabel } from "@/components/atoms/IconLabel";
 import { Input } from "@/components/atoms/Input";
 import {
@@ -30,7 +31,11 @@ export const SigninForm = () => {
   } = useForm<Signin>({ resolver: zodResolver(signinSchema) });
 
   const { onSubmit } = useSignin({
-    onCompleted: () => {
+    onCompleted: async (session) => {
+      if (session) {
+        // NOTE: awaitしないとmiddlewareの認証検証が失敗しリダイレクトされるためtokenが保存されるまで待機.
+        await setToken(session.token);
+      }
       successToast("ログインしました.");
       router.push("/");
     },


### PR DESCRIPTION
# Issue
- close: #38 

# 確認事項
- ログイン成功時にCookieにTokenが保存されていることを確認
- CookieにTokenが保存されている際にログインページへリダイレクトされないことを確認

# スクリーンショット
![image](https://github.com/user-attachments/assets/f360c57b-7ff3-4bc4-bdf0-b69141eedba8)
