### PR TITLE
【ストレージ】DeleteEntryConfirmDialogコンポーネントを作成

### DIFF
--- a/src/features/storage/components/organisms/DeleteEntryComfirmDialog/DeleteEntryConfirmDialog.stories.tsx
+++ b/src/features/storage/components/organisms/DeleteEntryComfirmDialog/DeleteEntryConfirmDialog.stories.tsx
@@ -1,0 +1,42 @@
+import { Meta, StoryObj } from "@storybook/nextjs";
+import { DeleteEntryConfirmDialog } from "./DeleteEntryConfirmDialog";
+import { fn } from "storybook/test";
+import { useState } from "react";
+import { Button } from "@/components/atoms/Button";
+import { refetchContext } from "@/providers/refetch";
+
+const meta = {
+  title: "Storage/Organisms/DeleteEntryConfirmDialog",
+  component: DeleteEntryConfirmDialog,
+  args: {
+    volumeName: "volume",
+    entryKey: "key/sample.txt",
+    open: false,
+    onOpenChange: fn(),
+  },
+  argTypes: {
+    open: {
+      control: false,
+    },
+  },
+} satisfies Meta<typeof DeleteEntryConfirmDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <refetchContext.Provider value={{ refetch: fn(), setRefetch: fn() }}>
+        <Button label="開く" onClick={() => setOpen(true)} />
+        <DeleteEntryConfirmDialog
+          {...args}
+          open={open}
+          onOpenChange={() => setOpen((v) => !v)}
+        />
+      </refetchContext.Provider>
+    );
+  },
+};

--- a/src/features/storage/components/organisms/DeleteEntryComfirmDialog/DeleteEntryConfirmDialog.test.tsx
+++ b/src/features/storage/components/organisms/DeleteEntryComfirmDialog/DeleteEntryConfirmDialog.test.tsx
@@ -1,0 +1,185 @@
+import { refetchContext } from "@/providers/refetch";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ReactNode } from "react";
+import { DeleteEntryConfirmDialog } from "./DeleteEntryConfirmDialog";
+import userEvent from "@testing-library/user-event";
+import { errorCode } from "@/lib/errors";
+
+const pushMock = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+const successToastMock = jest.fn();
+const errorToastMock = jest.fn();
+jest.mock("@/lib/toast", () => ({
+  successToast: (...args: unknown[]) => successToastMock(...args),
+  errorToast: (...args: unknown[]) => errorToastMock(...args),
+}));
+
+const deleteEntriesMock = jest.fn();
+jest.mock("@/features/storage/actions/delete-entries", () => ({
+  deleteEntries: () => deleteEntriesMock(),
+}));
+
+const onOpenChangeMock = jest.fn();
+const refetchMock = jest.fn();
+
+describe("Storage/Organisms/DeleteEntryConfirmDialog", () => {
+  const renderWithContext = (component: ReactNode) => {
+    render(
+      <refetchContext.Provider
+        value={{ refetch: refetchMock, setRefetch: jest.fn() }}
+      >
+        {component}
+      </refetchContext.Provider>,
+    );
+  };
+
+  it("renders", () => {
+    renderWithContext(
+      <DeleteEntryConfirmDialog
+        volumeName="volume"
+        entryKey="key/sample.txt"
+        open
+        onOpenChange={onOpenChangeMock}
+      />,
+    );
+    expect(screen.getByText("エントリー削除")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (content) =>
+          content.includes("「sample.txt」を削除しますか？") &&
+          content.includes("削除したエントリーは復元できません."),
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "削除" })).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    renderWithContext(
+      <DeleteEntryConfirmDialog
+        volumeName="volume"
+        entryKey="key/sample.txt"
+        open={false}
+        onOpenChange={onOpenChangeMock}
+      />,
+    );
+    expect(screen.queryByText("エントリー削除")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        (content) =>
+          content.includes("「sample.txt」を削除しますか？") &&
+          content.includes("削除したエントリーは復元できません."),
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "削除" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("invokes the success handler when delete succeeds", async () => {
+    deleteEntriesMock.mockResolvedValue({
+      "key/sample.txt": {
+        error: undefined,
+      },
+    });
+
+    renderWithContext(
+      <DeleteEntryConfirmDialog
+        volumeName="volume"
+        entryKey="key/sample.txt"
+        open
+        onOpenChange={onOpenChangeMock}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => {
+      expect(successToastMock).toHaveBeenCalledWith(
+        "エントリーを削除しました.",
+      );
+      expect(refetchMock).toHaveBeenCalled();
+      expect(onOpenChangeMock).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error toast when delete fails without error message", async () => {
+    deleteEntriesMock.mockResolvedValue({
+      "key/sample.txt": {
+        error: {
+          code: errorCode.InternalServerError,
+          message: "internal server error",
+        },
+      },
+    });
+
+    renderWithContext(
+      <DeleteEntryConfirmDialog
+        volumeName="volume"
+        entryKey="key/sample.txt"
+        open
+        onOpenChange={onOpenChangeMock}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => {
+      expect(errorToastMock).toHaveBeenCalled();
+    });
+  });
+
+  it("redirect to signin page when unauthenticated", async () => {
+    deleteEntriesMock.mockResolvedValue({
+      "key/sample.txt": {
+        error: {
+          code: errorCode.Unauthenticated,
+          message: "unauthenticated",
+        },
+      },
+    });
+
+    renderWithContext(
+      <DeleteEntryConfirmDialog
+        volumeName="volume"
+        entryKey="key/sample.txt"
+        open
+        onOpenChange={onOpenChangeMock}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/auth/signin");
+    });
+  });
+
+  it("redirect to signin page when unauthorized", async () => {
+    deleteEntriesMock.mockResolvedValue({
+      "key/sample.txt": {
+        error: {
+          code: errorCode.Unauthorized,
+          message: "unauthorized",
+        },
+      },
+    });
+
+    renderWithContext(
+      <DeleteEntryConfirmDialog
+        volumeName="volume"
+        entryKey="key/sample.txt"
+        open
+        onOpenChange={onOpenChangeMock}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/auth/signin");
+    });
+  });
+});

--- a/src/features/storage/components/organisms/DeleteEntryComfirmDialog/DeleteEntryConfirmDialog.tsx
+++ b/src/features/storage/components/organisms/DeleteEntryComfirmDialog/DeleteEntryConfirmDialog.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { ConfirmDialog } from "@/components/organisms/ConfirmDialog";
+import { deleteEntries } from "@/features/storage/actions/delete-entries";
+import { extractName } from "@/features/storage/lib/key";
+import { errorCode } from "@/lib/errors";
+import { errorToast, successToast } from "@/lib/toast";
+import { refetchContext } from "@/providers/refetch";
+import { useRouter } from "next/navigation";
+import { useContext } from "react";
+
+type Props = Readonly<{
+  volumeName: string;
+  entryKey: string;
+  open: boolean;
+  onOpenChange: () => void;
+}>;
+
+export const DeleteEntryConfirmDialog = ({
+  volumeName,
+  entryKey,
+  open,
+  onOpenChange,
+}: Props) => {
+  const router = useRouter();
+  const context = useContext(refetchContext);
+
+  const onApprove = async () => {
+    const res = await deleteEntries(volumeName, [entryKey]);
+    if (!res[`${entryKey}`].error) {
+      successToast("エントリーを削除しました.");
+      context.refetch();
+      onOpenChange();
+    } else {
+      if (
+        res[`${entryKey}`].error?.code === errorCode.Unauthenticated ||
+        res[`${entryKey}`].error?.code === errorCode.Unauthorized
+      ) {
+        router.push("/auth/signin");
+      } else {
+        errorToast();
+      }
+    }
+  };
+
+  return (
+    <ConfirmDialog
+      title="エントリー削除"
+      description={`「${extractName(entryKey)}」を削除しますか？\n削除したエントリーは復元できません.`}
+      approveLabel="削除"
+      open={open}
+      onOpenChange={onOpenChange}
+      onApprove={onApprove}
+    />
+  );
+};

--- a/src/features/storage/components/organisms/DeleteEntryComfirmDialog/index.tsx
+++ b/src/features/storage/components/organisms/DeleteEntryComfirmDialog/index.tsx
@@ -1,0 +1,1 @@
+export { DeleteEntryConfirmDialog } from "./DeleteEntryConfirmDialog";

--- a/src/features/storage/components/organisms/DeleteVolumeConfirmDialog/DeleteVolumeConfirmDialog.test.tsx
+++ b/src/features/storage/components/organisms/DeleteVolumeConfirmDialog/DeleteVolumeConfirmDialog.test.tsx
@@ -35,6 +35,7 @@ describe("Storage/Organisms/DeleteVolumeConfirmDialog", () => {
       </refetchContext.Provider>,
     );
   };
+
   it("renders", () => {
     renderWithContext(
       <DeleteVolumeConfirmDialog

--- a/src/features/storage/components/organisms/UpdateEntryFormDialog/UpdateEntryFormDialog.test.tsx
+++ b/src/features/storage/components/organisms/UpdateEntryFormDialog/UpdateEntryFormDialog.test.tsx
@@ -115,7 +115,9 @@ describe("Storage/Organisms/UpdateEntryFormDialog", () => {
     await userEvent.click(screen.getByRole("button", { name: "更新" }));
 
     await waitFor(() => {
-      expect(successToastMock).toHaveBeenCalled();
+      expect(successToastMock).toHaveBeenCalledWith(
+        "エントリーを更新しました.",
+      );
       expect(refetchMock).toHaveBeenCalled();
       expect(resetMock).toHaveBeenCalled();
       expect(onOpenChangeMock).toHaveBeenCalled();

--- a/src/features/storage/lib/key.ts
+++ b/src/features/storage/lib/key.ts
@@ -4,3 +4,7 @@ export const buildKey = (currentKey: string, name: string): string => {
   }
   return name;
 };
+
+export const extractName = (key: string): string => {
+  return key.split("/").at(-1) ?? "";
+};


### PR DESCRIPTION
# Issue
- close: #243 

# 確認事項
- Storybookでレンダリングされることを確認
- テストが通ることを確認

## スクリーンショット
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9e33a605-55fb-47e9-8af5-f572d69bef1c" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/70612b79-5785-4eca-80ff-b10ca2c0c09f" />
